### PR TITLE
Add option to only load a node instead of the whole body

### DIFF
--- a/src/listeners.ts
+++ b/src/listeners.ts
@@ -12,6 +12,7 @@ import {
 	$preloadMode,
 	$trackedAssets,
 	$delayBeforePreload,
+	$rootSelector,
 } from './snap';
 
 import {
@@ -114,7 +115,10 @@ export function readystatechange() {
 		const doc = document.implementation.createHTMLDocument('');
 		doc.documentElement.innerHTML = removeNoscriptTags($xhr.responseText);
 		$page.title = doc.title;
-		$page.body = <HTMLBodyElement>doc.body;
+		$page.body = <HTMLElement>doc.body;
+		if ($rootSelector) {
+			$page.body = $page.body.querySelector($rootSelector);
+		}
 
 		const alteredOnReceive = trigger(
 			'receive', $page.url, $page.body, $page.title

--- a/src/snap.ts
+++ b/src/snap.ts
@@ -25,7 +25,7 @@ export let $xhr: XMLHttpRequest;
 export const $page = {
 	url: '',
 	title: '',
-	body: <HTMLBodyElement> undefined
+	body: <HTMLElement> undefined
 };
 
 export const $state = {
@@ -48,11 +48,16 @@ export const $trackedAssets: Set<HTMLElement|string> = new Set();
 let $isDynamic = true;
 export let $preloadMode: PreloadMode = 'mouseover';
 export let $delayBeforePreload: number;
+export let $rootSelector: string;
 
 ////////// HELPERS //////////
 
 export function changePage(title: string, body, newUrl: string, scrollY?: number, pop?: boolean) {
-	document.documentElement.replaceChild(body, document.body);
+	let target = document.body;
+	if ($rootSelector)
+		target = target.querySelector($rootSelector);
+
+	target.parentNode.replaceChild(body, target);
 	// We cannot just use `document.body = doc.body`, it causes Safari (tested
 	// 5.1, 6.0 and Mobile 7.0) to execute script tags directly.
 
@@ -258,10 +263,11 @@ export function init(config: Config = {}) {
 	}
 
 	$isDynamic = !config.static;
+	$rootSelector = config.rootSelector || null;
 
 	$state.hashlessLocation = removeHash(location.href);
 	const record: HistoryRecord = {
-		body: <HTMLBodyElement> document.body,
+		body: <HTMLElement> document.body,
 		title: document.title,
 		scrollY: pageYOffset
 	};

--- a/typings/snap.d.ts
+++ b/typings/snap.d.ts
@@ -25,6 +25,7 @@ interface Config {
 	preloadMode?: PreloadMode;
 	delay?: number;
 	static?: boolean;
+	rootSelector?: string;
 }
 
 declare module '@alexlur/snap' {


### PR DESCRIPTION
This adds the "selector" option. When set, Snap will not replace the
whole document body with the new loaded body, but rather only the first
node that matches the selector (with `document.querySelector`) with the
matching node of the loaded page.

This makes it possible to easily persist some elements (i.e. chat
widgets that are added to the DOM by external libraries) across
navigation.

(I haven't tried to run the tests and haven't updated the doc, but it seems to work quite well for me so far, so I thought I'd share 😉)